### PR TITLE
Update link to 'bot framework SDK' at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The Bot Framework Emulator is a desktop application that allows bot developers to test and debug bots built using the [Bot Framework SDK](https://github.com/microsoft/botbuilder). You can use the Bot Framework Emulator to test bots running either locally on your machine or connect to bots running remotely through a tunnel.
 
-This repo is part the [Microsoft Bot Framework](https://github.com/microsoft/botframework) - a comprehensive framework for building enterprise-grade conversational AI experiences.
+This repo is part the [Microsoft Bot Framework](https://github.com/microsoft/botframework-sdk) - a comprehensive framework for building enterprise-grade conversational AI experiences.
 
 ## Download
 


### PR DESCRIPTION
Replace https://github.com/microsoft/botframework with
https://github.com/microsoft/botframework-sdk at README.md
since /botframework is deprecated (moved)